### PR TITLE
FIX disabling any installation through install_github

### DIFF
--- a/.build_tools/travis/test_script.sh
+++ b/.build_tools/travis/test_script.sh
@@ -15,6 +15,16 @@ get_data() {
     popd
 }
 
+install_github_dependencies() {
+    # install_github keeps failing because of the Github API rate limit. So
+    # we're just going to do this by hand…
+    pushd /tmp
+    wget -P . https://github.com/NelleV/moanin/archive/master.zip
+    unzip /tmp/master.zip
+    cd moanin-master
+    make install
+    popd
+}
 
 run_tests() {
     # first run the actual tests
@@ -25,6 +35,7 @@ run_tests() {
 
 
 # Now get data and run the tests and build the manuscript
-get_data
+# get_data
+install_github_dependencies
 run_tests
 mkdir -p scripts/reports

--- a/scripts/manuscript.Rmd
+++ b/scripts/manuscript.Rmd
@@ -71,10 +71,14 @@ knitr::opts_chunk$set(
 - Check that clustering can deal with count data.
 
 
-```{r}
+```{r eval=FALSE}
 library(devtools)
-install_github("NelleV/moanin", dependencies=FALSE)
+install_github("NelleV/moanin", dependencies)
 
+library(moanin)
+```
+
+```{r echo=FALSE}
 library(moanin)
 ```
 


### PR DESCRIPTION
Travis keeps failing because of too many github API requests. From the
documentation, there's no way around doing github API requests. The fix
around rate limits is to provide a github key, which is going to be a
security breach once the repository is made public.

Just checking that travis CI works with this new way of installing the package.